### PR TITLE
transactionの更新をevent emitter経由で流すように変更

### DIFF
--- a/InAppUtils/InAppUtils.h
+++ b/InAppUtils/InAppUtils.h
@@ -2,7 +2,8 @@
 #import <StoreKit/StoreKit.h>
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface InAppUtils : NSObject <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
+@interface InAppUtils : RCTEventEmitter <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
 
 @end

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -63,6 +63,27 @@ RCT_EXPORT_METHOD(finishTransaction:(NSString *)transactionIdentifier
   reject(@"E_TRANSACTION_NOT_FOUND", @"Transaction not found", nil);
 }
 
+RCT_EXPORT_METHOD(canPurchaseProduct:(NSString *)productIdentifier
+                            resolve:(RCTPromiseResolveBlock)resolve
+                             reject:(RCTPromiseRejectBlock)reject)
+{
+  NSArray *transactions = [[SKPaymentQueue defaultQueue] transactions];
+  for (int i = 0; i < transactions.count; i++) {
+    SKPaymentTransaction* t = transactions[i];
+    if (
+      (
+        t.transactionState == SKPaymentTransactionStatePurchasing ||
+        t.transactionState == SKPaymentTransactionStatePurchased
+      ) &&
+      [productIdentifier isEqualToString:t.payment.productIdentifier]
+    ) {
+      resolve(@"false");
+      return;
+    }
+  }
+  resolve(@"true");
+}
+
 NSString *const TRANSACTION_UPDATED_EVENT_NAME = @"transactionUpdated";
 
 - (NSArray<NSString *> *)supportedEvents


### PR DESCRIPTION
# 既存コードの設計

- ransactionの更新をcallbackで受け取る
- 受け取ったらすぐにfinishTransactionする

**-> iOSの課金概念と不整合が発生している**

# 変更後の設計

- transactionの更新をevent emitterで流すように
- finishTransactionは明示的に呼ぶ必要があるように
- pending transactionsを取得できるように
